### PR TITLE
Add aws service control policies

### DIFF
--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -11,7 +11,8 @@
                 "aws-portal:ViewPaymentMethods",
                 "aws-portal:ViewUsage",
                 "organizations:Describe*",
-                "organizations:List*"
+                "organizations:List*",
+                "cloudformation:*"
             ],
             "Resource": [
                 "*"

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -9,7 +9,9 @@
                 "aws-portal:ViewAccount",
                 "aws-portal:ViewBilling",
                 "aws-portal:ViewPaymentMethods",
-                "aws-portal:ViewUsage"
+                "aws-portal:ViewUsage",
+                "organizations:Describe*",
+                "organizations:List*"
             ],
             "Resource": [
                 "*"

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -12,7 +12,7 @@
                 "aws-portal:ViewUsage",
                 "organizations:Describe*",
                 "organizations:List*",
-                "cloudformation:*"
+                "cloudformation:*",
                 "s3:*"
             ],
             "Resource": [

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -2,20 +2,14 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "Allow IAM",
-            "Effect": "Deny",
-            "NotAction": [
-                "iam:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Allow STS",
             "Effect": "Allow",
             "Action": [
-                "sts:*"
+                "iam:*",
+                "sts:*",
+                "aws-portal:ViewAccount",
+                "aws-portal:ViewBilling",
+                "aws-portal:ViewPaymentMethods",
+                "aws-portal:ViewUsage"
             ],
             "Resource": [
                 "*"

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Allow IAM",
+            "Effect": "Deny",
+            "NotAction": [
+                "iam:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "Allow STS",
+            "Effect": "Allow",
+            "Action": [
+                "sts:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -13,6 +13,7 @@
                 "organizations:Describe*",
                 "organizations:List*",
                 "cloudformation:*"
+                "s3:*"
             ],
             "Resource": [
                 "*"

--- a/aws/allow-iam.json
+++ b/aws/allow-iam.json
@@ -13,7 +13,8 @@
                 "organizations:Describe*",
                 "organizations:List*",
                 "cloudformation:*",
-                "s3:*"
+                "s3:*",
+                "sns:ListTopics"
             ],
             "Resource": [
                 "*"

--- a/aws/deny-cloudtrail.json
+++ b/aws/deny-cloudtrail.json
@@ -5,7 +5,8 @@
             "Sid": "Stmt1499264169000",
             "Effect": "Deny",
             "Action": [
-                "cloudtrail:DeleteTrail"
+                "cloudtrail:DeleteTrail",
+                "cloudtrail:StopLogging"
             ],
             "Resource": [
                 "*"

--- a/aws/deny-cloudtrail.json
+++ b/aws/deny-cloudtrail.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1499264169000",
+            "Effect": "Deny",
+            "Action": [
+                "cloudtrail:DeleteTrail"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Following service control policies which do the following:
 - Stop people from removing/modifying cloudtrail
 - Stop people from creating non-iam resources in the identity account